### PR TITLE
windows: add correct volume name and better effort for product and manufacturer

### DIFF
--- a/discotool/discotool.py
+++ b/discotool/discotool.py
@@ -99,6 +99,8 @@ def displayTheBoardsList(bList, ports=[]):
 		for volume in dev_vols:
 			if 'mount_point' in volume:
 				click.echo("\t"+volume['mount_point'],nl=False)
+				if volume['name'] not in volume['mount_point']:
+					click.echo(' "'+volume['name']+'"', nl=False)
 				for main in volume['mains']:
 					click.echo(" ("+main+")",nl=False)
 				if dev['version']:
@@ -134,8 +136,8 @@ def find_the_devices(deviceList, auto, wait, name, serial, mount):
 	if mount != "":
 		for device in deviceList:
 			for volume in device['volumes']:
-				if 'mount_point' in volume \
-					and volume['mount_point'].lower().find(mount) >= 0:
+				if 'name' in volume \
+					and volume['name'].lower().find(mount) >= 0:
 					if device not in selectedDevices:
 						selectedDevices.append(device)
 	return selectedDevices

--- a/discotool/usbinfos/usbinfos_win32.py
+++ b/discotool/usbinfos/usbinfos_win32.py
@@ -19,7 +19,7 @@ def get_devices_list(drive_info=False):
 	deviceList = []
 
 	serialNumbers = [{"serial_number": x.serial_number} for x in remainingPorts]
-	
+
 	allMounts = []
 	wmi_info = wmi.WMI()
 	for physical_disk in wmi_info.Win32_DiskDrive ():
@@ -66,14 +66,17 @@ def get_devices_list(drive_info=False):
 		deviceVolumes = []
 		for mount in allMounts:
 			if mount["disk"].SerialNumber == device['serial_number']:
-				if name == "":
-					name = mount["disk"].caption
+				if mount["disk"].caption:
+					# guessing the Manufacturer is the first word (for now)
+					manufacturer = mount["disk"].caption.split(" ")[0] or manufacturer
+					# guessing it ends with "USB Device"
+					name = " ".join(mount["disk"].caption.split(" ")[1:-2]) or name
 				for disk in mount["volumes"]:
 					volume = disk.DeviceID
 					if drive_info:
 						mains,version = get_cp_drive_info(volume)
 					deviceVolumes.append({
-						'name': name,
+						'name': disk.VolumeName,
 						'mount_point': volume+"\\",
 						'mains': mains,
 					})


### PR DESCRIPTION
On windows: better board information retrieved from the drive information: product (name) and manufacturer.
- this would only works if the board has a the drive currently mounted
- it's parsing the drive "caption" assuming manufacturer is a single word
- both are limited to 16 characters in the caption string (or *anywhere* I have seen so far)

There seems to be a way to retrieve product and manufacturer independently from a different PNPEntity (still linked to the drive and still limited to 16 chars though).

Also, get the actual volume name and print it on windows. (Or if the name is not in the mount point in general, which is the case on windows because the mount point is a letter).

All platforms: filter by "mount" using the volume name, not the mount point (can't filter with windows letter but who cares).