### PR TITLE
windows: further attempts to get manufacturer and product name

### DIFF
--- a/discotool/usbinfos/usbinfos_win32.py
+++ b/discotool/usbinfos/usbinfos_win32.py
@@ -26,15 +26,14 @@ def get_devices_list(drive_info=False):
 		if physical_disk.InterfaceType != "USB": continue
 		volumes = []
 		manufacturer, product = "", ""
-		# last element of the PNP "path" or something
-		pnp_id = physical_disk.PNPDeviceID.split("\\")[-1]
+		pnp_id = physical_disk.PNPDeviceID.replace("\\","#")
 		for partition in physical_disk.associators ("Win32_DiskDriveToDiskPartition"):
 			for logical_disk in partition.associators ("Win32_LogicalDiskToPartition"):
 				if logical_disk.DriveType == 2: # removable
 					volumes.append(logical_disk)
 					# try to find info from related "windows portable drive" entity
 					for ppi in wmi_info.Win32_PnPEntity(pnpclass="WPD"):
-						if f"#{pnp_id}#" in ppi.PNPDeviceID:
+						if pnp_id in ppi.PNPDeviceID:
 							manufacturer = ppi.manufacturer or manufacturer
 							product = ppi.description or product
 		# default information from the caption

--- a/discotool/usbinfos/usbinfos_win32.py
+++ b/discotool/usbinfos/usbinfos_win32.py
@@ -25,11 +25,27 @@ def get_devices_list(drive_info=False):
 	for physical_disk in wmi_info.Win32_DiskDrive ():
 		if physical_disk.InterfaceType != "USB": continue
 		volumes = []
+		manufacturer, product = "", ""
+		# last element of the PNP "path" or something
+		pnp_id = physical_disk.PNPDeviceID.split("\\")[-1]
 		for partition in physical_disk.associators ("Win32_DiskDriveToDiskPartition"):
 			for logical_disk in partition.associators ("Win32_LogicalDiskToPartition"):
 				if logical_disk.DriveType == 2: # removable
 					volumes.append(logical_disk)
+					# try to find info from related "windows portable drive" entity
+					for ppi in wmi_info.Win32_PnPEntity(pnpclass="WPD"):
+						if f"#{pnp_id}#" in ppi.PNPDeviceID:
+							manufacturer = ppi.manufacturer or manufacturer
+							product = ppi.description or product
+		# default information from the caption
+		if physical_disk.caption:
+			# guessing the Manufacturer is the first word
+			manufacturer = manufacturer or physical_disk.caption.split(" ")[0]
+			# guessing it ends with "USB Device"
+			product = product or " ".join(physical_disk.caption.split(" ")[1:-2])
 		allMounts.append({
+			"manufacturer": manufacturer.strip(),
+			"product": product.strip(),
 			"disk": physical_disk,
 			"volumes": volumes,
 		})
@@ -66,11 +82,10 @@ def get_devices_list(drive_info=False):
 		deviceVolumes = []
 		for mount in allMounts:
 			if mount["disk"].SerialNumber == device['serial_number']:
-				if mount["disk"].caption:
-					# guessing the Manufacturer is the first word (for now)
-					manufacturer = mount["disk"].caption.split(" ")[0] or manufacturer
-					# guessing it ends with "USB Device"
-					name = " ".join(mount["disk"].caption.split(" ")[1:-2]) or name
+				if mount["manufacturer"]:
+					manufacturer = mount["manufacturer"]
+				if mount["product"]:
+					name = mount["product"]
 				for disk in mount["volumes"]:
 					volume = disk.DeviceID
 					if drive_info:


### PR DESCRIPTION
This uses the associated "WPD" (Windows Portable Drive) PNP entity, associating them using the PNPDeviceID string.
The drive's PNPDeviceID is part of the WPD's PNPDeviceID with `#` as separators... Not sure where that's documented.
While still limited to 16 characters, this contains the Manufacturer and Product strings separately.