### PR TITLE
Add devices_by_vidpid to filter devices by vid and pid.

### DIFF
--- a/discotool/__init__.py
+++ b/discotool/__init__.py
@@ -5,6 +5,7 @@ from .usbinfos import (
 	devices_by_name,
 	devices_by_drive,
 	devices_by_serial,
+	devices_by_vidpid,
 )
 
 try:

--- a/discotool/discotool.py
+++ b/discotool/discotool.py
@@ -10,6 +10,8 @@ import subprocess
 import sys
 import time
 from . import usbinfos
+from .usbinfos import port_is_repl, port_is_data
+
 
 DEFAULT_WINDOWS_SERIAL_TOOLS = {
 	"ttermpro": "ttermpro.exe /C={portnum}",
@@ -73,19 +75,6 @@ def setup_command_tools():
 				echo(f"{environ_var}={os.environ[environ_var]}", underline=True)
 
 
-# string description of the circuitpython REPL and secondary serial port
-# generic, stringcar_m0_express, winterbloom_sol
-SERIAL_NAMES = ["CircuitPython","StringCarM0Ex","Sol"]
-EXT_REPL = " CDC "
-EXT_CDC2 = " CDC2 "
-
-def IS_REPL(iface):
-	return any([(n + EXT_REPL).lower() in iface.lower() for n in SERIAL_NAMES])
-
-def IS_CDC2(iface):
-	return any([(n + EXT_CDC2).lower() in iface.lower() for n in SERIAL_NAMES])
-
-
 # print the text from main
 def displayTheBoardsList(bList, ports=[]):
 	if len(bList) == 0 and len(ports) == 0:
@@ -110,9 +99,9 @@ def displayTheBoardsList(bList, ports=[]):
 		)
 		for portInfo in dev_ports:
 			iface = portInfo['iface']
-			if IS_REPL(iface):
+			if port_is_repl(iface):
 				iface = "REPL"
-			elif IS_CDC2(iface):
+			elif port_is_data(iface):
 				iface = "DATA"
 			click.echo(f"\t{portInfo['dev']} ({iface})")
 		# volumes and main files
@@ -333,7 +322,7 @@ def repl(ctx):
 			port = device['ports'][0]
 		else:
 			potential_ports = [pp for pp in device['ports']
-				if IS_REPL(pp['iface'])]
+				if port_is_repl(pp['iface'])]
 			if len(potential_ports) == 0:
 				port = device['ports'][0]
 			else:
@@ -583,12 +572,12 @@ def get(ctx, key):
 			if 'ports' in device:
 				device['ports'].sort(key = lambda port: port['dev'])
 				values += [pp['dev'] for pp in device['ports']
-					if IS_REPL(pp['iface'])]
+					if port_is_repl(pp['iface'])]
 		elif key in ("cdc2", "data"):
 			if 'ports' in device:
 				device['ports'].sort(key = lambda port: port['dev'])
 				values += [pp['dev'] for pp in device['ports']
-					if IS_CDC2(pp['iface'])]
+					if port_is_data(pp['iface'])]
 		elif key == "vid":
 			values.append(device['vendor_id'])
 		elif key == "pid":

--- a/examples/find_boards_by_volume.py
+++ b/examples/find_boards_by_volume.py
@@ -3,37 +3,30 @@ A demo host-side script that
 - finds a board by volume name
 - sends some data to the board's data serial port
 
-python3 find_boards_by_volume.py -m CIRCUITPY -d "Hi there"
+python3 find_boards_by_volume.py --mount QTPY2040 ---data "Hi there"
 """
 import argparse
 import discotool
 import os
 import serial
 
-BOARD_DRIVE_NAME = "QTPY2040"
+BOARD_DRIVE_NAME = "CIRCUITPY"
 DATA_STRING = "Hello World"
 
+# This lets you specify the drive name and data to send in the command line
 parser = argparse.ArgumentParser()
-parser.add_argument(
-    "--mount",
-    "-m",
-    type=str,
-    help="Name of the board's mount",
-    default=BOARD_DRIVE_NAME,
-)
-parser.add_argument(
-    "--data",
-    "-d",
-    type=str,
-    help="The data string to send",
-    default=DATA_STRING,
-)
+parser.add_argument("--mount", type=str, help="Drive name", default=BOARD_DRIVE_NAME)
+parser.add_argument("--data", type=str, help="Data to send", default=DATA_STRING)
 args = parser.parse_args()
 
+# prepare the parameters
 mount_name = os.path.basename(args.mount)
 data_string = args.data.encode("utf8")
 
+# find all the devices
 devs = discotool.get_identified_devices()
+
+# and now drill into it to the the correct one
 for dev in devs:
     volume = dev.volume_name
     data_port = dev.data

--- a/examples/find_boards_with_filters.py
+++ b/examples/find_boards_with_filters.py
@@ -1,0 +1,43 @@
+"""
+A demo host-side script that
+- finds a board by product name ("pico", "macropad", "featherS3"...)
+- sends some data to the board's data serial port
+
+python3 find_boards_with_filters.py --name FeatherS3 ---data "Hi there"
+"""
+import argparse
+import discotool
+import os
+import serial
+
+PRODUCT_NAME = "QT PY"  # not case sensitive
+DATA_STRING = "Hello World"
+
+# This lets you specify the drive name and data to send in the command line
+parser = argparse.ArgumentParser()
+parser.add_argument("--name", type=str, help="Product name", default="")
+parser.add_argument("--data", type=str, help="Data to send", default=DATA_STRING)
+parser.add_argument("--vid", type=int, help="Product name", default=0)
+args = parser.parse_args()
+
+# prepare the parameters
+product_name = args.name
+data_string = args.data.encode("utf8")
+vid = args.vid
+
+# use filters based on given parameters
+if vid != 0 and product_name == "":
+    pad = discotool.devices_by_vidpid(vid)
+elif not product_name:
+    pad = discotool.devices_by_name(PRODUCT_NAME)
+else:
+    pad = discotool.devices_by_name(product_name)
+
+# send data to whatever is found
+if pad and (data_port := pad[0].data):
+    print(f"Board found: {pad[0].name}")
+    print(f"Send {data_string} to {data_port}")
+    with serial.Serial(data_port) as pp:
+        pp.write(data_string)
+else:
+    print(f"Could not find a {product_name} with an open data port.")


### PR DESCRIPTION
The pid is optionnal.
Make DeviceInfoDict.data and DeviceInfoDict.repl better.
If no actual repl port is found, it's the first port found that is not data.

Examples:
Add comments in the find_board_by_volume example.
Add example with a couple of filter functions.

Internal:
Moved IS_REPL and IS_DATA into the commin library and renamed.