### PR TITLE
Add usb location

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ Devices list (MacOS)
 		'mains': ['code.py'],
 		'mount_point': '/Volumes/CIRCUITPY',
 		'name': 'CIRCUITPY'
-	}]
+	}],
+	'usb_location': '0x14630000'
 }]
 ```
 
@@ -118,6 +119,23 @@ Devices list (MacOS)
 ### The DeviceInfoDict class
 The device list is actually a list of DeviceInfoDict, a subclass of dictionary that adds a few properties as shortcuts for paths in the dictionary, with a default value of `None`.
 
+Dictionary entries:
+- **`name`**: USB name of the board (str).
+- **`manufacturer`**: USB manufacturer of the board (str).
+- **`product_id`**: USB Product ID (int).
+- **`vendor_id`**: USB Vendor ID (int).
+- **`serial_num`**: USB Serial number of the board (str).
+- **`version`**: Circuitpython version, if found.
+- **`ports`**: list of serial ports found on the board, dictionaries.
+	- **`dev`**: port device, used to connect to the port. COM port on windows, dev path on linux (str).
+	- **`iface`**: interface name for the serial port (str).
+- **`volumes`**: list of mounted drives from the board, dictionaries.
+	- **`name`**: drive name, usually `CIRCUITPY` for Circuitpython or `*BOOT` for a UF2 bootloader drive (str).
+	- **`mount_point`**: mount path of the drive, letter on windows (str).
+	- **`mains`**: list of "main" files for Circuitpython (code.py etc.), by order of priority.
+- **`usb_location`**: an identifier for the USB port the board is connected to, should be consistent across reboots and modes (bootloader/application). 
+
+Shortcuts:
 - **`repl`**: REPL port, if any.
 - **`data`**: data port, if any.
 - **`drive`** and **`volume`**: board drive path.

--- a/discotool/usbinfos/usbinfos_linux.py
+++ b/discotool/usbinfos/usbinfos_linux.py
@@ -75,15 +75,20 @@ def get_devices_list(drive_info=False):
 						'mains': mains,
 					})
 		#
-		# go through parents and find "devpath", remove matching parents
+		# the issue is that we might find duplicates of devices, by finding
+		# a parent and treating it as the device. So, when we find a device
+		# that has parents that are previously found devices, we remove
+		# said parents.
 		def noParent(dev):
-			for papa in device.traverse():
-				if devpath.startswith(dev['devpath']):
-					return False
+			# test if the already found device is a parent of the current device
+			# do we need to loop through its parents ?
+			if devpath.startswith(dev['devpath']):
+				return False
 			return True
-		deviceList = list(filter(noParent,deviceList))
+		deviceList = list(filter(noParent, deviceList))
 		#
-		if vid not in VIDS and len(ttys) == 0: continue
+		if vid not in VIDS and len(ttys) == 0:
+			continue
 		#
 		curDevice = {}
 		curDevice['version'] = version
@@ -95,6 +100,7 @@ def get_devices_list(drive_info=False):
 		curDevice['serial_num'] = SN
 		curDevice['ports'] = ttys
 		curDevice['manufacturer'] = manufacturer
+		curDevice['usb_location'] = devpath.split("/", 4)[-1]
 		deviceList.append(curDevice)
 	#
 	for i in range(len(deviceList)):

--- a/discotool/usbinfos/usbinfos_macos.py
+++ b/discotool/usbinfos/usbinfos_macos.py
@@ -123,6 +123,7 @@ def readSysProfile(profile, devices, allMounts, drive_info):
 						})
 		curDevice['volumes'] = deviceVolumes
 		curDevice['version'] = version
+		curDevice['location'] = subGroup['location_id'].split(" ")[0]
 		devices += [curDevice]
 	return devices
 

--- a/discotool/usbinfos/usbinfos_macos.py
+++ b/discotool/usbinfos/usbinfos_macos.py
@@ -123,7 +123,7 @@ def readSysProfile(profile, devices, allMounts, drive_info):
 						})
 		curDevice['volumes'] = deviceVolumes
 		curDevice['version'] = version
-		curDevice['location'] = subGroup['location_id'].split(" ")[0]
+		curDevice['usb_location'] = subGroup['location_id'].split(" ")[0]
 		devices += [curDevice]
 	return devices
 

--- a/discotool/usbinfos/usbinfos_win32.py
+++ b/discotool/usbinfos/usbinfos_win32.py
@@ -132,7 +132,7 @@ def get_devices_list(drive_info=False):
 		curDevice['volumes'] = deviceVolumes
 		curDevice['ports'] = ttys
 		curDevice['version'] = version
-		curDevice['location'] = location
+		curDevice['usb_location'] = location
 		deviceList.append(curDevice)
 
 	rp = [port.device for port in remainingPorts]

--- a/discotool/usbinfos/usbinfos_win32.py
+++ b/discotool/usbinfos/usbinfos_win32.py
@@ -69,12 +69,13 @@ def get_devices_list(drive_info=False):
 		curDevice = {}
 		deviceVolumes = []
 		name = ""
-		SN = device
+		SN = device.upper()
 
 		ttys = []
 		vid = "0"
 		pid = "0"
 		manufacturer = ""
+		location = ""
 		for port in list(remainingPorts):
 			if port.serial_number == SN:
 				vid = port.vid
@@ -121,15 +122,17 @@ def get_devices_list(drive_info=False):
 			desc = descriptors[uid]
 			manufacturer = desc.manufacturer or manufacturer
 			name = desc.product or name
+			location = desc.location or location
 
-		curDevice['version'] = version
-		curDevice['volumes'] = deviceVolumes
 		curDevice['name'] = name
+		curDevice['manufacturer'] = manufacturer
 		curDevice['vendor_id'] = int(vid)
 		curDevice['product_id'] = int(pid)
 		curDevice['serial_num'] = SN
+		curDevice['volumes'] = deviceVolumes
 		curDevice['ports'] = ttys
-		curDevice['manufacturer'] = manufacturer
+		curDevice['version'] = version
+		curDevice['location'] = location
 		deviceList.append(curDevice)
 
 	rp = [port.device for port in remainingPorts]

--- a/tests/locations.py
+++ b/tests/locations.py
@@ -21,6 +21,6 @@ for device in discotool.get_identified_devices():
 	print("Dict indexes:")
 # 	for x in device:
 # 		print(f"{x:12s} : {device[x]}")
-	print("location :", device["location"])
+	print("location :", device["usb_location"])
 
 display("")

--- a/tests/locations.py
+++ b/tests/locations.py
@@ -11,15 +11,16 @@ def display(texte):
 # display('Device class/dictionnary                       ')
 for device in discotool.get_identified_devices():
 	display(device.name)
-	print(type(device))
-	print("Attributes:")
-	print(sorted([
-		attr for
-		attr in set(dir(device)) - set(dir({"un":1}))
-		if attr[0:2] != "__"
-	]))
+	# print(type(device))
+# 	print("Attributes:")
+# 	print(sorted([
+# 		attr for
+# 		attr in set(dir(device)) - set(dir({"un":1}))
+# 		if attr[0:2] != "__"
+# 	]))
 	print("Dict indexes:")
-	for x in device:
-		print(f"{x:12s} : {device[x]}")
+# 	for x in device:
+# 		print(f"{x:12s} : {device[x]}")
+	print("location :", device["location"])
 
 display("")

--- a/tests/locations.py
+++ b/tests/locations.py
@@ -1,0 +1,25 @@
+import discotool
+
+def display(texte):
+	print(("-" * 70) + "\n-", texte.ljust(70-3) + "-\n" + ("-" * 70))
+
+# display('get_devices_list()                             ')
+# deviceList,remainingPorts = discotool.get_devices_list()
+# print(deviceList)
+# print(remainingPorts)
+
+# display('Device class/dictionnary                       ')
+for device in discotool.get_identified_devices():
+	display(device.name)
+	print(type(device))
+	print("Attributes:")
+	print(sorted([
+		attr for
+		attr in set(dir(device)) - set(dir({"un":1}))
+		if attr[0:2] != "__"
+	]))
+	print("Dict indexes:")
+	for x in device:
+		print(f"{x:12s} : {device[x]}")
+
+display("")


### PR DESCRIPTION
`usb_location` is a new entry to the device information, platform dependent it represents the USB path of the device, and should be consistent across resets and modes, like bootloader and Circuitpython, allowing to identify a board that has been rebooted into a new mode without changing the port it's plugged into.